### PR TITLE
Changing to a github dependency breaks mix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,5 @@ RUN mix local.hex --force && mix local.rebar --force
 
 COPY . .
 RUN mix deps.get
+RUN mix compile
+# RUN mix test

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule ElixirWithGleam.MixProject do
   defp deps do
     [
       {:mix_gleam, "~> 0.1.0"},
-      {:gleam_stdlib, "~> 0.9.0"}
+      # {:gleam_stdlib, "~> 0.9.0"}
+      {:gleam_stdlib, github: "gleam-lang/stdlib"}
       # {:gleam_stdlib, path: "./stdlib"}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ElixirWithGleam.MixProject do
     [
       {:mix_gleam, "~> 0.1.0"},
       # {:gleam_stdlib, "~> 0.9.0"}
-      {:gleam_stdlib, github: "gleam-lang/stdlib"}
+      {:gleam_stdlib, github: "gleam-lang/stdlib", manager: :rebar3}
       # {:gleam_stdlib, path: "./stdlib"}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "gleam_stdlib": {:hex, :gleam_stdlib, "0.9.0", "d1323850e8c1481d8d6661ee572dd54d5f0f1c2ccef208a0adebb72183b7b465", [:rebar3], [], "hexpm", "01cf1c5d9047121f1f88913448df3fe7f9016c6f7d98a9729219a06c4d88395d"},
+  "gleam_stdlib": {:git, "https://github.com/gleam-lang/stdlib.git", "f88c132f3407f85a4580968d149c0f53a50d06b6", []},
   "mix_gleam": {:hex, :mix_gleam, "0.1.0", "a0cee5d30de865124a32ca6cd53b64c3e2ac57f12adf6e47b88fb673f47c716e", [:mix], [], "hexpm", "9ff518e6aab444c7f2e74038f9383020ef89810cf1f4402911f33b202ffd72e7"},
 }


### PR DESCRIPTION
This project works fine on master, the test calls into some Gleam code.

Switching a dependency to come from github does not correctly compile the Gleam code from another module. So here the Gleam code in this project is compiled but the standard library is not.

It seems that Gleam is compiled to erlang in the dependencies, you can see `gleam@atom.erl` by listing `deps/gleam_stdlib/gen/src/` But those erlang modules are not available when running this application.

The test fails with the following error, indicating stlib modules are not available

```
  1) test greets the world (ElixirWithGleamTest)
     test/elixir_with_gleam_test.exs:5
     ** (UndefinedFunctionError) function :gleam@string.reverse/1 is undefined (module :gleam@string is not available)
     code: assert ElixirWithGleam.hello() == "!maelg morf ,olleH"
     stacktrace:
       :gleam@string.reverse("Hello, from gleam!")
       test/elixir_with_gleam_test.exs:6: (test)
```

